### PR TITLE
Simple compatibility with Item Collection module

### DIFF
--- a/module/party-inventory.js
+++ b/module/party-inventory.js
@@ -77,7 +77,10 @@ Hooks.on('renderActorSheet5eCharacter', (sheet, html, character) => {
         addTogglePartyButton(html, sheet.actor);
     }
 });
-
+Hooks.on('renderItemSheet5eWithBags', (sheet, html, item) => {
+  let sheetClasses = sheet.options.classes;
+  addTogglePartyButton(html, sheet.object);
+});
 Hooks.on('getActorSheet5eCharacterHeaderButtons', (app, buttons) => {
     buttons.unshift({
         class: 'open-party-inventory-button',

--- a/module/sheet-inject.js
+++ b/module/sheet-inject.js
@@ -4,7 +4,7 @@ export function addTogglePartyButton(html, actor) {
     const enableTitle = game.i18n.localize(`${localizationID}.enable-item-title`);
     const disableTitle = game.i18n.localize(`${localizationID}.disable-item-title`);
 
-    html.find(".inventory ol:not(.currency-list)  .item-control.item-edit").each(function() {
+    html.find(".inventory ol:not(.currency-list)  .item-control.item-edit, .itemcollection-details ol:not(.currency-list) .item-control.item-edit").each(function() {
         const currentItemId = this.closest(".item").dataset.itemId;
         const currentItem = actor.items.find(item => item.id === currentItemId);
         const isInPartyInventory = currentItem.getFlag(moduleId, 'inPartyInventory');


### PR DESCRIPTION
Added a few modifications to support recursive inventory traversal to improve interoperability with Item Collection module. Saw a request for this modification here: https://github.com/teroparvinen/foundry-party-inventory/issues/6 and had already implemented the changes for my own use, so thought others might benefit as well.

Could certainly be made more robust, I'm sure, but it seems to work fine as-is.